### PR TITLE
Handle the fact that KCL will always set subSequenceNumber to 0

### DIFF
--- a/include/erlmld.hrl
+++ b/include/erlmld.hrl
@@ -9,11 +9,13 @@
           sub :: undefined | non_neg_integer(),
 
           %% record sub-sequence number for records NOT using KPL aggregation.
-          %% Your code is expected to fake these when needed.
+          %% erlmld supports its own KPL-like aggregation and will fill this
+          %% one when needed. For other use cases, your code is expected to
+          %% fake these when needed.
           user_sub :: undefined | non_neg_integer(),
 
           %% total number of records in aggregated KPL record:
-          %% (sub will range from 0 to user_total-1)
+          %% (user_sub will range from 0 to user_total-1)
           user_total :: undefined | non_neg_integer()
          }).
 

--- a/include/erlmld.hrl
+++ b/include/erlmld.hrl
@@ -8,9 +8,13 @@
           %% record sub-sequence number for records using KPL aggregation:
           sub :: undefined | non_neg_integer(),
 
+          %% record sub-sequence number for records NOT using KPL aggregation.
+          %% Your code is expected to fake these when needed.
+          user_sub :: undefined | non_neg_integer(),
+
           %% total number of records in aggregated KPL record:
-          %% (sub will range from 0 to total-1)
-          total :: undefined | non_neg_integer()
+          %% (sub will range from 0 to user_total-1)
+          user_total :: undefined | non_neg_integer()
          }).
 
 -record(checkpoint, {

--- a/src/erlmld_batch_processor.erl
+++ b/src/erlmld_batch_processor.erl
@@ -328,7 +328,7 @@ update_watchdog(#state{watchdog_timeout_ms = WatchdogTimeout,
     State#state{watchdog = Ref}.
 
 
-is_sub_record(#sequence_number{sub = Sub, total = Total})
+is_sub_record(#sequence_number{sub = Sub, user_total = Total})
   when is_integer(Sub) andalso is_integer(Total)
        andalso Sub < Total - 1 ->
     true;
@@ -378,9 +378,9 @@ checkpointing_subrecord_test() ->
     State = #state{enable_subsequence_checkpoints = false},
     ?assertEqual(undefined, next_checkpoint(State)),
 
-    SN0 = #sequence_number{sub = 0, total = 3},
-    SN1 = #sequence_number{sub = 1, total = 3},
-    SN2 = #sequence_number{sub = 2, total = 3},
+    SN0 = #sequence_number{sub = 0, user_total = 3},
+    SN1 = #sequence_number{sub = 1, user_total = 3},
+    SN2 = #sequence_number{sub = 2, user_total = 3},
     SN3 = #sequence_number{},
 
     %% items 0 and 2 completed and checkpointable, but not all subrecords have completed,
@@ -425,9 +425,9 @@ watchdog_test() ->
 
 is_sub_record_test() ->
     ?assertEqual(true, is_sub_record(#sequence_number{sub = 0,
-                                                      total = 2})),
+                                                      user_total = 2})),
     ?assertEqual(false, is_sub_record(#sequence_number{sub = 1,
-                                                       total = 2})),
+                                                       user_total = 2})),
     ?assertEqual(false, is_sub_record(#sequence_number{sub = undefined,
-                                                       total = undefined})).
+                                                       user_total = undefined})).
 -endif.

--- a/src/erlmld_batch_processor.erl
+++ b/src/erlmld_batch_processor.erl
@@ -327,8 +327,12 @@ update_watchdog(#state{watchdog_timeout_ms = WatchdogTimeout,
     {ok, Ref} = timer:exit_after(WatchdogTimeout, watchdog_timeout),
     State#state{watchdog = Ref}.
 
-
-is_sub_record(#sequence_number{sub = Sub, user_total = Total})
+%% We use user_sub here instead of sub: for KPL records, those values will be
+%% the same. For our own KPL-like protocol user_sub will be filled in, and
+%% in other use cases it will be undefined. In both of these last cases sub
+%% will be the original KCL sent (0, possible) so it can't be really used to
+%% know if this is a subrecord or not.
+is_sub_record(#sequence_number{user_sub = Sub, user_total = Total})
   when is_integer(Sub) andalso is_integer(Total)
        andalso Sub < Total - 1 ->
     true;

--- a/src/erlmld_batch_processor.erl
+++ b/src/erlmld_batch_processor.erl
@@ -382,9 +382,9 @@ checkpointing_subrecord_test() ->
     State = #state{enable_subsequence_checkpoints = false},
     ?assertEqual(undefined, next_checkpoint(State)),
 
-    SN0 = #sequence_number{sub = 0, user_total = 3},
-    SN1 = #sequence_number{sub = 1, user_total = 3},
-    SN2 = #sequence_number{sub = 2, user_total = 3},
+    SN0 = #sequence_number{user_sub = 0, user_total = 3},
+    SN1 = #sequence_number{user_sub = 1, user_total = 3},
+    SN2 = #sequence_number{user_sub = 2, user_total = 3},
     SN3 = #sequence_number{},
 
     %% items 0 and 2 completed and checkpointable, but not all subrecords have completed,
@@ -428,10 +428,10 @@ watchdog_test() ->
 
 
 is_sub_record_test() ->
-    ?assertEqual(true, is_sub_record(#sequence_number{sub = 0,
+    ?assertEqual(true, is_sub_record(#sequence_number{user_sub = 0,
                                                       user_total = 2})),
-    ?assertEqual(false, is_sub_record(#sequence_number{sub = 1,
+    ?assertEqual(false, is_sub_record(#sequence_number{user_sub = 1,
                                                        user_total = 2})),
-    ?assertEqual(false, is_sub_record(#sequence_number{sub = undefined,
+    ?assertEqual(false, is_sub_record(#sequence_number{user_sub = undefined,
                                                        user_total = undefined})).
 -endif.


### PR DESCRIPTION
These changes aim to better handle the fact that KCL will always set `subSequenceNumber` to 0.

A new field is added to `#sequence_number{}` called `user_sub` to keep track of "own-rolled-aggregated-records". The `sub` field is always set to the original value KCL sent for `subSequenceNumber`.

The proposed change will support the 3 use cases in the following way:

1. For standard KPL aggregated records, `sub` and `user_sub` will be set to the same value (original value sent by KCL for `subSequenceNumber`.
2. For our custom KPL version, `sub` is preserved as above, and `user_sub` is set to the right sub sequence number. 
3. For non-kpl aggregated records, the `sub` value is ignored and `user_sub` is set to `undefined`, so the caller can de-aggregate and decide how to handle it.
