### PR TITLE
Making log message optional, propagating checkpoint downstream

### DIFF
--- a/src/erlmld_batch_processor.erl
+++ b/src/erlmld_batch_processor.erl
@@ -33,7 +33,7 @@
 -export([initialize/3,
          ready/1,
          process_record/2,
-         checkpoint/3,
+         checkpointed/3,
          shutdown/2]).
 
 -include("erlmld.hrl").
@@ -122,7 +122,7 @@ process_record(#state{last_flush_time = LastFlush,
     end,
     maybe_checkpoint(update_watchdog(NState)).
 
-checkpoint(#state{log_checkpoints = LogCheckpoints} = State,
+checkpointed(#state{log_checkpoints = LogCheckpoints} = State,
            SequenceNumber,
            Checkpoint) ->
     case LogCheckpoints of

--- a/src/erlmld_batch_processor.erl
+++ b/src/erlmld_batch_processor.erl
@@ -33,6 +33,7 @@
 -export([initialize/3,
          ready/1,
          process_record/2,
+         checkpoint/3,
          shutdown/2]).
 
 -include("erlmld.hrl").
@@ -46,6 +47,10 @@
 
     %% Optional callback to call each time process_record returns a checkpoint.
     on_checkpoint :: fun((term(), shard_id()) -> term()),
+
+    %% Optional, false by default. Tells whether to log or not every successful
+    %% checkpoint from the KCL worker.
+    log_checkpoints :: boolean(),
 
     description :: term(),
     shard_id :: shard_id(),
@@ -71,12 +76,14 @@
 
 initialize(Opts, ShardId, ISN) ->
     Defaults = #{on_checkpoint => fun(_, _) -> ok end,
+                 log_checkpoints => false,
                  description => undefined,
                  enable_subsequence_checkpoints => false},
     #{description := Description,
       flusher_mod := FlusherMod,
       flusher_mod_data := FlusherModData,
       on_checkpoint := OnCheckpoint,
+      log_checkpoints := LogCheckpoints,
       flush_interval_ms := FlushIntervalMs,
       checkpoint_interval_ms := CheckpointIntervalMs,
       watchdog_timeout_ms := WatchdogTimeoutMs,
@@ -85,6 +92,7 @@ initialize(Opts, ShardId, ISN) ->
         flusher_mod = FlusherMod,
         flusher_state = FlusherMod:init(ShardId, FlusherModData),
         on_checkpoint = OnCheckpoint,
+        log_checkpoints = LogCheckpoints,
         description = Description,
         shard_id = ShardId,
         flush_interval_ms = FlushIntervalMs,
@@ -114,6 +122,14 @@ process_record(#state{last_flush_time = LastFlush,
     end,
     maybe_checkpoint(update_watchdog(NState)).
 
+checkpoint(#state{log_checkpoints = LogCheckpoints} = State,
+           SequenceNumber,
+           Checkpoint) ->
+    case LogCheckpoints of
+        true -> error_logger:info_msg("~p checkpointed at ~p (~p)~n", [State, Checkpoint, SequenceNumber]);
+        false -> ok
+    end,
+    {ok, State}.
 
 shutdown(#state{description = Description,
                 shard_id = ShardId,

--- a/src/erlmld_noisy_wrk.erl
+++ b/src/erlmld_noisy_wrk.erl
@@ -14,7 +14,7 @@
 -export([initialize/3,
          ready/1,
          process_record/2,
-         checkpoint/3,
+         checkpointed/3,
          shutdown/2]).
 
 -include("erlmld.hrl").
@@ -43,7 +43,7 @@ process_record(#state{shard_id = ShardId, count = Count} = State,
             {ok, State#state{count = Count + 1}}
     end.
 
-checkpoint(#state{shard_id = ShardId, count = Count} = State,
+checkpointed(#state{shard_id = ShardId, count = Count} = State,
            SequenceNumber,
            Checkpoint
 ) ->

--- a/src/erlmld_noisy_wrk.erl
+++ b/src/erlmld_noisy_wrk.erl
@@ -14,6 +14,7 @@
 -export([initialize/3,
          ready/1,
          process_record/2,
+         checkpoint/3,
          shutdown/2]).
 
 -include("erlmld.hrl").
@@ -42,6 +43,12 @@ process_record(#state{shard_id = ShardId, count = Count} = State,
             {ok, State#state{count = Count + 1}}
     end.
 
+checkpoint(#state{shard_id = ShardId, count = Count} = State,
+           SequenceNumber,
+           Checkpoint
+) ->
+    io:format("~p (~p) checkpointed at ~p (~p)~n", [ShardId, Count, Checkpoint, SequenceNumber]),
+    {ok, State}.
 
 shutdown(#state{shard_id = ShardId, count = Count}, Reason) ->
     io:format("~p (~p) shutting down, reason: ~p~n", [ShardId, Count, Reason]),

--- a/src/erlmld_worker.erl
+++ b/src/erlmld_worker.erl
@@ -63,6 +63,10 @@
         | {ok, worker_state(), checkpoint()}
         | {error, term()}.
 
+-callback checkpoint(worker_state(), sequence_number(), checkpoint()) ->
+    {ok, worker_state()}
+        | {error, term()}.
+
 -callback shutdown(worker_state(), shutdown_reason()) ->
     ok
         | {ok, checkpoint()}

--- a/src/erlmld_worker.erl
+++ b/src/erlmld_worker.erl
@@ -63,7 +63,7 @@
         | {ok, worker_state(), checkpoint()}
         | {error, term()}.
 
--callback checkpoint(worker_state(), sequence_number(), checkpoint()) ->
+-callback checkpointed(worker_state(), sequence_number(), checkpoint()) ->
     {ok, worker_state()}
         | {error, term()}.
 

--- a/src/erlmld_wrk_statem.erl
+++ b/src/erlmld_wrk_statem.erl
@@ -417,7 +417,7 @@ handle_event(?INTERNAL, #{<<"action">> := <<"checkpoint">>} = R,
   when CheckpointState == ?CHECKPOINT;
        CheckpointState == ?SHUTDOWN_CHECKPOINT ->
     SN = sequence_number(R),
-    case Mod:checkpoint(WorkerState, SN, Checkpoint) of
+    case Mod:checkpointed(WorkerState, SN, Checkpoint) of
         {ok, NWorkerState} ->
             NData = worker_state(Data, NWorkerState),
             case CheckpointState of

--- a/src/erlmld_wrk_statem.erl
+++ b/src/erlmld_wrk_statem.erl
@@ -410,21 +410,25 @@ handle_event(?INTERNAL, #{<<"action">> := <<"checkpoint">>,
 
 handle_event(?INTERNAL, #{<<"action">> := <<"checkpoint">>} = R,
              {?DISPATCH, CheckpointState},
-             #data{worker_state = {ok, WorkerState},
+             #data{handler_module = Mod,
+                   worker_state = {ok, WorkerState},
                    last_checkpoint = Checkpoint,
                    last_request = LastAction} = Data)
   when CheckpointState == ?CHECKPOINT;
        CheckpointState == ?SHUTDOWN_CHECKPOINT ->
-    %% successful checkpoint. fixme; provide indication of success to worker?
     SN = sequence_number(R),
-    error_logger:info_msg("~p checkpointed at ~p (~p)~n", [WorkerState, Checkpoint, SN]),
-    case CheckpointState of
-        ?CHECKPOINT ->
-            {next_state, ?PROCESS_RECORDS, Data};
-        ?SHUTDOWN_CHECKPOINT ->
-            success(LastAction, Data, ?SHUTDOWN)
+    case Mod:checkpoint(WorkerState, SN, Checkpoint) of
+        {ok, NWorkerState} ->
+            NData = worker_state(Data, NWorkerState),
+            case CheckpointState of
+                ?CHECKPOINT ->
+                    {next_state, ?PROCESS_RECORDS, NData};
+                ?SHUTDOWN_CHECKPOINT ->
+                    success(LastAction, NData, ?SHUTDOWN)
+          end;
+        {error, _} = Error ->
+            {stop, Error}
     end;
-
 
 %% we were processing records and we attempted to checkpoint, but failed because another
 %% worker stole our lease.  abort record processing, return a 'success' response for


### PR DESCRIPTION
This PR aims to make it optional (configurable) the message that's being printed by every checkpoint (because in practice this message repeats quite often and clutters logs.

Also, the checkpoint event is sent to the worker just in case it wants to handle it somehow.