### PR TITLE
Revert "Update dependencies to their latest versions"

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,14 +2,14 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-        {jiffy, "0.15.2"},
-        {erlexec, "1.9.1"},
+        {jiffy, "0.14.11"},
+        {erlexec, "1.7.1"},
         {b64fast, "0.2.1"}
        ]}.
 
 
 {plugins, [rebar3_gpb_plugin,
-           {pc, "1.10.0"}
+           {pc, {git, "https://github.com/blt/port_compiler.git", {tag, "v1.1.0"}}}
           ]}.
 
 {erl_opts, [{i, "./_build/default/plugins/gpb/include"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,10 @@
 {"1.1.0",
 [{<<"b64fast">>,{pkg,<<"b64fast">>,<<"0.2.1">>},0},
- {<<"erlexec">>,{pkg,<<"erlexec">>,<<"1.9.1">>},0},
- {<<"jiffy">>,{pkg,<<"jiffy">>,<<"0.15.2">>},0}]}.
+ {<<"erlexec">>,{pkg,<<"erlexec">>,<<"1.7.1">>},0},
+ {<<"jiffy">>,{pkg,<<"jiffy">>,<<"0.14.11">>},0}]}.
 [
 {pkg_hash,[
  {<<"b64fast">>, <<"EF67EFD73109BF52A83338A2DED30D0DC4EC1B11449B4C43DB970D3FC96CC9CD">>},
- {<<"erlexec">>, <<"3774940C8FC1A65CDBC5FE99D66BE1C63D0562B805D24A04B954AB2049342004">>},
- {<<"jiffy">>, <<"DE266C390111FD4EA28B9302F0BC3D7472468F3B8E0ACEABFBEFA26D08CD73B7">>}]}
+ {<<"erlexec">>, <<"6DDBD40FA202084ED0BDAF95A50C334ACAA5644AE213B903CD4094A78AE79734">>},
+ {<<"jiffy">>, <<"919A87D491C5A6B5E3BBC27FAFEDC3A0761CA0B4C405394F121F582FD4E3F0E5">>}]}
 ].


### PR DESCRIPTION
Reverts AdRoll/erlmld#7 since many of our production systems use OTP20 still and this change is not backwards compatible.