### PR TITLE
version updates

### DIFF
--- a/priv/download.sh
+++ b/priv/download.sh
@@ -6,7 +6,7 @@
 set -eu
 
 DYNAMO_PKG="dynamodb-streams-kinesis-adapter"
-DYNAMO_VERSION="1.2.1"
+DYNAMO_VERSION="1.4.0"
 
 msg () {
     echo "$@" >&2

--- a/rebar.config
+++ b/rebar.config
@@ -8,9 +8,9 @@
        ]}.
 
 
-{plugins, [rebar3_gpb_plugin,
-           {pc, {git, "https://github.com/blt/port_compiler.git", {tag, "v1.1.0"}}}
-          ]}.
+{plugins, [
+    { rebar3_gpb_plugin, "2.3.2" }
+]}.
 
 {erl_opts, [{i, "./_build/default/plugins/gpb/include"}]}.
 
@@ -35,6 +35,7 @@
    [
     {plugins, [pc]},
     {artifacts, ["priv/b64fast.so"]},
+    {so_name, "b64fast.so"},
     {provider_hooks, [
                       {post,
                        [{compile, {pc, compile}},


### PR DESCRIPTION
- update dynamodb streams adapter package to latest version (uses KCL 1.9)
   - as a result, roles used with kinesis stream processors may need a new `kinesis:ListShards` permission on the streams being processed
- remove explicit port compiler plugin ref
- use explicit gpb plugin ref
- set `so_name` in b64fast overrides