### PR TITLE
use separate directories for kcl and dynamo streams jars

### DIFF
--- a/priv/.gitignore
+++ b/priv/.gitignore
@@ -1,1 +1,2 @@
-jars
+ddb_jars
+kcl_jars

--- a/priv/download.sh
+++ b/priv/download.sh
@@ -1,27 +1,34 @@
 #!/bin/bash
 #
 #    Download the latest released AWS DynamoDB streams adapter and all required
-#    dependencies (one of which is the KCL) to ./jars.  Requires maven.
+#    dependencies (one of which is the KCL) to ./ddb_jars.  Similarly and separately
+#    downloads KCL 1.9 and all required dependencies to ./kcl_jars.
+#
+#    Requires maven.
 #
 set -eu
 
+cd "$(dirname $0)"
+R="$(pwd)"
+
 DYNAMO_PKG="dynamodb-streams-kinesis-adapter"
 DYNAMO_VERSION="1.4.0"
+DYNAMO_DESTDIR="$R/ddb_jars"
+
+KCL_PKG="amazon-kinesis-client"
+KCL_VERSION="1.9.1"
+KCL_DESTDIR="$R/kcl_jars"
+
+BASE="http://search.maven.org/remotecontent?filepath="
 
 msg () {
     echo "$@" >&2
 }
 
-cd "$(dirname $0)"
-R="$(pwd)"
-DESTDIR="$R/jars"
-mkdir -p "$DESTDIR"
-
-BASE="http://search.maven.org/remotecontent?filepath="
-
 download () {
-    PKG="$1"
-    VERSION="$2"
+    DESTDIR="$1"
+    PKG="$2"
+    VERSION="$3"
     PREFIX="com/amazonaws/$PKG/$VERSION/$PKG-$VERSION"
     TYPES="pom jar"
     mkdir -p "$DESTDIR"
@@ -38,6 +45,7 @@ download () {
     mvn -B -f "$POM" dependency:copy-dependencies -DoutputDirectory="$DESTDIR"
 }
 
-download "$DYNAMO_PKG" "$DYNAMO_VERSION"
+download "$DYNAMO_DESTDIR" "$DYNAMO_PKG" "$DYNAMO_VERSION"
+download "$KCL_DESTDIR" "$KCL_PKG" "$KCL_VERSION"
 
 echo "done"

--- a/priv/run_dynamo.sh
+++ b/priv/run_dynamo.sh
@@ -5,7 +5,7 @@
 #    properties file is added to the classpath, and it is referenced by filename.  The
 #    directory containing this script is appended to PATH.
 #
-#    The "./jars" directory relative to this script should have been populated by
+#    The "./ddb_jars" directory relative to this script should have been populated by
 #    $0/download.sh.
 #
 #    The streamName value in the supplied properties value should be the ARN of a DynamoDB
@@ -25,4 +25,4 @@ CLASS=com.amazonaws.services.dynamodbv2.streamsadapter.StreamsMultiLangDaemon
 
 export PATH="$PATH:$R"
 
-"$JAVA" -cp "$R/jars/*":"$(dirname $1)" $CLASS "$(basename $1)"
+"$JAVA" -cp "$R/ddb_jars/*":"$(dirname $1)" $CLASS "$(basename $1)"

--- a/priv/run_kinesis.sh
+++ b/priv/run_kinesis.sh
@@ -5,7 +5,7 @@
 #    and it is referenced by filename.  The directory containing this script is appended
 #    to PATH.
 #
-#    The "./jars" directory relative to this script should have been populated by
+#    The "./kcl_jars" directory relative to this script should have been populated by
 #    $0/download.sh.
 #
 set -euo pipefail
@@ -22,4 +22,4 @@ CLASS=com.amazonaws.services.kinesis.multilang.MultiLangDaemon
 
 export PATH="$PATH:$R"
 
-"$JAVA" -cp "$R/jars/*":"$(dirname $1)" $CLASS "$(basename $1)"
+"$JAVA" -cp "$R/kcl_jars/*":"$(dirname $1)" $CLASS "$(basename $1)"

--- a/src/erlmld.app.src
+++ b/src/erlmld.app.src
@@ -6,7 +6,7 @@
   {maintainers, ["AdRoll RTB team <rtb-team+erlmld@adroll.com>"]},
   {licenses, ["BSD 3-Clause License"]},
   {links, [{"Github", "https://github.com/AdRoll/erlmld"}]},
-  {exclude_files, ["priv/ddb_jars", "priv/kcl_jars"]},
+  {exclude_files, ["priv/jars", "priv/ddb_jars", "priv/kcl_jars"]},
   %% note: these names are only registered if app_suffix is undefined.  otherwise, these
   %% are the prefixes of names which are registered:
   {registered, [erlmld_sup,

--- a/src/erlmld.app.src
+++ b/src/erlmld.app.src
@@ -6,7 +6,7 @@
   {maintainers, ["AdRoll RTB team <rtb-team+erlmld@adroll.com>"]},
   {licenses, ["BSD 3-Clause License"]},
   {links, [{"Github", "https://github.com/AdRoll/erlmld"}]},
-  {exclude_files, ["priv/jars"]},
+  {exclude_files, ["priv/ddb_jars", "priv/kcl_jars"]},
   %% note: these names are only registered if app_suffix is undefined.  otherwise, these
   %% are the prefixes of names which are registered:
   {registered, [erlmld_sup,


### PR DESCRIPTION
Sidestep any versioning issues by giving each component its own
classpath.  This allows an erlmd-using application to process both
Kinesis and DynamoDB streams using independent and potentially
incompatible versions of the KCL and dynamodb streams adapter
libraries.