### PR TITLE
allow erlmld_worker:ready/1 callback to checkpoint

### DIFF
--- a/src/erlmld_batch_processor.erl
+++ b/src/erlmld_batch_processor.erl
@@ -106,19 +106,14 @@ initialize(Opts, ShardId, ISN) ->
 
 
 ready(#state{flusher_mod = FMod, flusher_state = FState} = State) ->
+    {ok, NFState, Tokens} = FMod:heartbeat(FState),
+    NState = flusher_state(State, NFState),
     NNState =
-        case erlang:function_exported(FMod, ready, 1) of
-            true ->
-                {ok, NFState, Tokens} = FMod:ready(FState),
-                NState = flusher_state(State, NFState),
-                case Tokens of
-                    [] ->
-                        NState;
-                    _ ->
-                        note_success(note_flush(NState), Tokens)
-                end;
-            false ->
-                State
+        case Tokens of
+            [] ->
+                NState;
+            _ ->
+                note_success(note_flush(NState), Tokens)
         end,
     maybe_checkpoint(update_watchdog(NNState)).
 

--- a/src/erlmld_flusher.erl
+++ b/src/erlmld_flusher.erl
@@ -29,12 +29,20 @@
 %%%     The batch processor handles checkpointing and decides when to trigger
 %%%     flushing.
 %%%
+%%%     If stream volume is low, a flusher module should implement ready/1,
+%%%     which if exported will be called regardless of whether any records
+%%%     could be obtained from the stream.  It may return the same values as
+%%%     flush/2.  If it returns a non-empty list of tokens as the third tuple
+%%%     element, it is considered to have just performed a partial flush.
+%%%
 %%% @end
 %%% Created : 20 Dec 2016 by Constantin Berzan <constantin.berzan@adroll.com>
 
 -module(erlmld_flusher).
 
 -include("erlmld.hrl").
+
+-optional_callbacks([ready/1]).
 
 -callback init(shard_id(), term()) ->
     flusher_state().
@@ -45,5 +53,9 @@
         | {error, full | term()}.
 
 -callback flush(flusher_state(), partial | full) ->
+    {ok, flusher_state(), list(flusher_token())}
+        | {error, term()}.
+
+-callback ready(flusher_state()) ->
     {ok, flusher_state(), list(flusher_token())}
         | {error, term()}.

--- a/src/erlmld_worker.erl
+++ b/src/erlmld_worker.erl
@@ -26,9 +26,11 @@
 %%%    at the most recent sequence number.
 %%%
 %%%    Before starting to process each batch of records, a worker's ready/1 callback is
-%%%    called, which should return a possibly-updated worker state.  This can be useful
-%%%    when a record processor is using a watchdog timer and is far behind on a stream
-%%%    (and so won't receive any actual records for a while).
+%%%    called, which should return a possibly-updated worker state and possibly a
+%%%    checkpoint.  This can be useful when a record processor is using a watchdog timer
+%%%    and is far behind on a stream (and so won't receive any actual records for a
+%%%    while), or if a stream has very low volume (records seen less frequently than
+%%%    desired checkpoint or flush intervals).
 %%%
 %%%    When a shard lease has been lost or a shard has been completely processed, a worker
 %%%    will be shut down.  If the lease was lost, the worker will receive a reason of
@@ -56,6 +58,7 @@
 
 -callback ready(worker_state()) ->
     {ok, worker_state()}
+        | {ok, worker_state(), checkpoint()}
         | {error, term()}.
 
 -callback process_record(worker_state(), stream_record()) ->


### PR DESCRIPTION
- `erlmld_worker:ready/1` behavior callback may now checkpoint (same as `erlmld_worker:process_record/2`)

- new required `erlmld_flusher:heartbeat/1` behavior callback added which may return same result as `erlmld_flusher:flush/2`.  if it returns any tokens, treated as if a flush occurred.

With these changes, when using an `erlmld_flusher`-implementing module with `erlmld_batch_processor`, it should no longer be possible to be permanently stuck in a state where `erlmld_batch_processor` is waiting on the flusher, which is itself waiting on more events from the batch processor before flushing anything (such as might happen when processing a low-volume stream with records appearing less frequently than the desired checkpoint or flush intervals).

Now, a flusher module's `heartbeat/1` will be called periodically (and before each record batch) even if no records are available on the stream, giving it an opportunity to flush even if its batch is not full.