### PR TITLE
[RTI-9528] Adjust for OTP23

### DIFF
--- a/include/erlmld.hrl
+++ b/include/erlmld.hrl
@@ -1,7 +1,3 @@
--ifndef(ERLMLD_HRL).
-
--define(ERLMLD_HRL, true).
-
 -record(sequence_number,
         {%% overall record sequence number:
          base :: undefined | non_neg_integer() | atom(),
@@ -45,5 +41,3 @@
 %% magic number identifying deflate-compressed KPL record, compressed using
 %% zlib:compress/1.  the KPL checksum trailer is included in the deflated data.
 -define(KPL_AGG_MAGIC_DEFLATED, <<16#01, 16#89, 16#9A, 16#C2>>).
-
--endif.

--- a/rebar.config
+++ b/rebar.config
@@ -6,10 +6,10 @@
 {plugins, [rebar3_gpb_plugin]}.
 
 {project_plugins,
- [{rebar3_hex, "~> 6.11.0"},
-  {rebar3_format, "~> 1.0.0"},
+ [{rebar3_hex, "~> 6.11.3"},
+  {rebar3_format, "~> 1.0.1"},
   {rebar3_lint, "~> 0.4.0"},
-  {rebar3_hank, "~> 0.4.0"}]}.
+  {rebar3_hank, "~> 1.1.1"}]}.
 
 {gpb_opts,
  [{i, "priv/proto"},


### PR DESCRIPTION
I had to remove the macro due to AdRoll/rebar3_hank#137
I checked and the file is not imported twice in any of our projects.