### PR TITLE
[RTI-10319] Upgrade Java libraries to handle log4j vulnerability

### DIFF
--- a/priv/download.sh
+++ b/priv/download.sh
@@ -12,11 +12,11 @@ cd "$(dirname $0)"
 R="$(pwd)"
 
 DYNAMO_PKG="dynamodb-streams-kinesis-adapter"
-DYNAMO_VERSION="1.4.0"
+DYNAMO_VERSION="1.5.3"
 DYNAMO_DESTDIR="$R/ddb_jars"
 
 KCL_PKG="amazon-kinesis-client"
-KCL_VERSION="1.9.1"
+KCL_VERSION="1.14.5"
 KCL_DESTDIR="$R/kcl_jars"
 
 BASE="http://search.maven.org/remotecontent?filepath="

--- a/priv/download.sh
+++ b/priv/download.sh
@@ -42,7 +42,7 @@ download () {
         fi
     done
     POM="$DESTDIR/$PKG-$VERSION.pom"
-    mvn -B -f "$POM" dependency:copy-dependencies -DoutputDirectory="$DESTDIR"
+    mvn -B -f "$POM" dependency:copy-dependencies -DoutputDirectory="$DESTDIR" -DincludeScope=runtime
 }
 
 download "$DYNAMO_DESTDIR" "$DYNAMO_PKG" "$DYNAMO_VERSION"


### PR DESCRIPTION
### Notes

- The latest version of `amazon-kinesis-client` uses `log4j-core-2.15.0.jar` and `log4j-api-2.6.2.jar`
- The latest version of `dynamodb-streams-kinesis-adapter` ships with `log4j-api-2.13.3` and `log4j-core-2.13.3`, but they're only used for testing as proved by its dependency tree (see below)
- I wrote awslabs/dynamodb-streams-kinesis-adapter#49, nonetheless, to ask for an update.

#### `dynamodb-streams-kinesis-adapter` dep tree
```java
[INFO] --- maven-dependency-plugin:3.0.0:tree (default-cli) @ dynamodb-streams-kinesis-adapter ---
[INFO] com.amazonaws:dynamodb-streams-kinesis-adapter:jar:1.5.3
[INFO] +- com.amazonaws:aws-java-sdk-cloudwatch:jar:1.11.1016:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.11.1016:compile
[INFO] |  |  …
[INFO] |  \- com.amazonaws:jmespath-java:jar:1.11.1016:compile
[INFO] +- com.amazonaws:aws-java-sdk-dynamodb:jar:1.11.1016:compile
[INFO] |  …
[INFO] …
[INFO] \- com.amazonaws:DynamoDBLocal:jar:1.17.1:test
[INFO]    +- org.antlr:antlr4-runtime:jar:4.5:test
[INFO]    …
[INFO]    +- org.apache.logging.log4j:log4j-api:jar:2.13.3:test
[INFO]    +- org.apache.logging.log4j:log4j-core:jar:2.13.3:test
[INFO]    …
[INFO]    \- org.mockito:mockito-core:jar:1.10.19:test
[INFO]       \- org.objenesis:objenesis:jar:2.1:test
```