### PR TITLE
[dep-up] Get this project ready for rebar3_depup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,10 +22,10 @@
 {plugins, [rebar3_gpb_plugin]}.
 
 {project_plugins,
- [{rebar3_hex, "~> 6.11.4"},
+ [{rebar3_hex, "~> 6.11.9"},
   {rebar3_format, "~> 1.0.1"},
-  {rebar3_lint, "~> 0.4.0"},
-  {rebar3_hank, "~> 1.1.2"}]}.
+  {rebar3_lint, "~> 1.0.1"},
+  {rebar3_hank, "~> 1.2.2"}]}.
 
 {gpb_opts,
  [{i, "priv/proto"},
@@ -66,3 +66,5 @@
     %% dynamically replaced in an .properties file. We can't detect unused
     %% configuration options. They're technically all used.
     "src/erlmld.app.src"]}]}.
+
+{depup, [{ignore, [erlexec]}]}.

--- a/src/erlmld_batch_processor.erl
+++ b/src/erlmld_batch_processor.erl
@@ -28,7 +28,7 @@
 %%% based on original code by Mike Watters <mike.watters@adroll.com>
 -module(erlmld_batch_processor).
 
--behavior(erlmld_worker).
+-behaviour(erlmld_worker).
 
 -export([initialize/3, ready/1, process_record/2, checkpointed/3, shutdown/2]).
 

--- a/src/erlmld_noisy_wrk.erl
+++ b/src/erlmld_noisy_wrk.erl
@@ -9,7 +9,7 @@
 
 -module(erlmld_noisy_wrk).
 
--behavior(erlmld_worker).
+-behaviour(erlmld_worker).
 
 -export([initialize/3, ready/1, process_record/2, checkpointed/3, shutdown/2]).
 


### PR DESCRIPTION
We can't upgrade `erlexec`, so we couldn't originally include this project on our list of upgradable projects before AdRoll/rebar3_depup#11