### PR TITLE
Make hex.pm happy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,8 @@
  [{rebar3_hex, "~> 7.0.2"},
   {rebar3_format, "~> 1.2.1"},
   {rebar3_lint, "~> 1.1.0"},
-  {rebar3_hank, "~> 1.3.0"}]}.
+  {rebar3_hank, "~> 1.3.0"},
+  rebar3_ex_doc]}.
 
 {gpb_opts,
  [{i, "priv/proto"},
@@ -58,3 +59,10 @@
     "src/erlmld.app.src"]}]}.
 
 {depup, [{ignore, [erlexec]}]}.
+
+{hex, [{doc, ex_doc}]}.
+
+{ex_doc, [
+          {source_url, <<"https://github.com/AdRoll/erlmld">>},
+          {extras, [<<"README.md">>, <<"LICENSE">>]},
+          {main, <<"readme">>}]}.

--- a/src/erlmld.app.src
+++ b/src/erlmld.app.src
@@ -5,8 +5,7 @@
    "DynamoDB streams and shards in a single node using the Kinesis Client "
    "Library and MultiLangDaemon."},
   {vsn, "git"},
-  {maintainers, ["AdRoll RTB team <rtb-team+erlmld@adroll.com>"]},
-  {licenses, ["BSD 3-Clause License"]},
+  {licenses, ["BSD-3-Clause"]},
   {links, [{"Github", "https://github.com/AdRoll/erlmld"}]},
   {exclude_files,
    ["priv/jars",


### PR DESCRIPTION
This was what I needed to do to make hex.pm accept the package. I initially branched from the last release's commit, so hex didn't get any newer code changes. Afterward, I merged the latest changes from main, at github's insistence.


- rebar.config:
  - needed docs configured
- erlmld.app.src
  - remove maintainers line (deprecated)
  - standardize license identifier
