### PR TITLE
CI: use otp 25.2.1

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['23.3', '24.3']
+        otp: ['23.3', '24.3', '25.2.1']
         rebar: ['3.20.0']
 
     steps:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -2,6 +2,9 @@ name: Erlang CI
 
 on: [push, pull_request]
 
+env:
+  ERL_FLAGS: "-enable-feature all"
+
 jobs:
 
   build:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:


### PR DESCRIPTION
I had to change the ubuntu version because ubuntu-latest is the 22.04 and according to https://github.com/erlef/setup-beam that one doesn't have otp23