### PR TITLE
[RTI-15742] Close connection after writing the last checkpoint

### DIFF
--- a/src/erlmld_wrk_statem.erl
+++ b/src/erlmld_wrk_statem.erl
@@ -477,7 +477,7 @@ handle_event(info, Message, _State, #data{worker_state = WorkerState}) ->
     error_logger:error_msg("~p ignoring unexpected message ~p~n", [WorkerState, Message]),
     keep_state_and_data;
 handle_event(state_timeout, shutdown, _State, _Data) ->
-    stop.
+    {stop, {error, shutdown_timeout}}.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/erlmld_wrk_statem.erl
+++ b/src/erlmld_wrk_statem.erl
@@ -476,7 +476,6 @@ handle_event(info, {tcp, _Socket, _Bin}, _State, _Data) ->
 handle_event(info, Message, _State, #data{worker_state = WorkerState}) ->
     error_logger:error_msg("~p ignoring unexpected message ~p~n", [WorkerState, Message]),
     keep_state_and_data;
-
 handle_event(state_timeout, shutdown, _State, _Data) ->
     stop.
 

--- a/src/erlmld_wrk_statem.erl
+++ b/src/erlmld_wrk_statem.erl
@@ -465,7 +465,10 @@ handle_event(?INTERNAL,
             %% next state is waiting for the MLD to close the connection.
             %% But it might not happen, so we'll close it ourselves after a timeout.
             Timeout = application:get_env(erlmld, shutdown_timeout, 5000),
-            {next_state, {?PEER_READ, Kind}, activate(Data), [{{timeout, shutdown}, Timeout, shutdown}]};
+            {next_state,
+             {?PEER_READ, Kind},
+             activate(Data),
+             [{{timeout, shutdown}, Timeout, shutdown}]};
         _ ->
             {next_state, {?PEER_READ, NextReadKind}, activate(Data)}
     end;
@@ -476,7 +479,6 @@ handle_event(info, {tcp, _Socket, _Bin}, _State, _Data) ->
 handle_event(info, Message, _State, #data{worker_state = WorkerState}) ->
     error_logger:error_msg("~p ignoring unexpected message ~p~n", [WorkerState, Message]),
     keep_state_and_data;
-
 handle_event({timeout, shutdown}, shutdown, _State, _Data) ->
     {stop, {error, shutdown_timeout}}.
 

--- a/src/erlmld_wrk_statem.erl
+++ b/src/erlmld_wrk_statem.erl
@@ -187,6 +187,7 @@ handle_event({call, From}, {accepted, Socket}, ?INIT, Data) ->
 %% shutdown action (MLD will read our response, then close its stream to us, then await
 %% our exit).
 handle_event(info, {tcp_closed, _}, {?PEER_READ, ?SHUTDOWN}, _) ->
+    error_logger:info_msg("shutdown message received, shutting down normally~n"),
     stop;
 %% connection was closed, but we didn't expect it.
 handle_event(info, {tcp_closed, _}, _State, _) ->
@@ -480,6 +481,7 @@ handle_event(info, Message, _State, #data{worker_state = WorkerState}) ->
     error_logger:error_msg("~p ignoring unexpected message ~p~n", [WorkerState, Message]),
     keep_state_and_data;
 handle_event({timeout, shutdown}, shutdown, _State, _Data) ->
+    error_logger:error_msg("timeout reached while waiting for SHUTDOWN message, shutdown forced~n"),
     {stop, {error, shutdown_timeout}}.
 
 %%%===================================================================

--- a/src/erlmld_wrk_statem.erl
+++ b/src/erlmld_wrk_statem.erl
@@ -461,11 +461,11 @@ handle_event(?INTERNAL,
     end,
     ok = gen_tcp:send(Socket, [IoData, "\n"]),
     case NextReadKind of
-        ?SHUTDOWN ->
+        Kind when Kind == ?SHUTDOWN; Kind == ?SHUTDOWN_CHECKPOINT ->
             %% next state is waiting for the MLD to close the connection.
             %% But it might not happen, so we'll close it ourselves after a timeout.
             %% Note that this timeout gets cancelled if we have state changes before it fires.
-            {next_state, {?PEER_READ, ?SHUTDOWN}, activate(Data), [{state_timeout, 5000, shutdown}]};
+            {next_state, {?PEER_READ, Kind}, activate(Data), [{state_timeout, 5000, shutdown}]};
         _ ->
             {next_state, {?PEER_READ, NextReadKind}, activate(Data)}
     end;


### PR DESCRIPTION
Close connection after writing the last checkpoint when receiving a terminate event.

This PR adds a state_timeout (see [gen_statem state-timeout](https://www.erlang.org/doc/design_principles/statem#state-time-outs)), this timeout will be cancelled if there's a state change (which will happen _if_ we get a response). If we want to trigger the timeout regardless of state changes, we can use a [generic timeout](https://www.erlang.org/doc/design_principles/statem#generic-time-outs).

The way this timeout works is by inserting the timeout trigger when setting state to `{?PEER_READ, ?SHUTDOWN}` so this timeout will protect us from staleness in both cases of [terminate, {ok, Checkpoint}}](https://github.com/AdRoll/erlmld/blob/ecb92de09d2d923fed40df472b3785ff4e5cd7b9/src/erlmld_wrk_statem.erl#L256) and [{_, ok}](https://github.com/AdRoll/erlmld/blob/ecb92de09d2d923fed40df472b3785ff4e5cd7b9/src/erlmld_wrk_statem.erl#L265) in the MLD shutdown handler. Because both `success/3` and `shutdown_checkpoint/2` set next state to `{?PEER_WRITE, ?SHUTDOWN}` or `{?PEER_WRITE, ?SHUTDOWN_CHECKPOINT}` with the `{write, IoData}` event.

**UPDATE:**
* PR now only handles  `{?PEER_READ, ?SHUTDOWN}`
* We use generic timeout instead of state timeout, so timeout always triggers regardless of state changes.
